### PR TITLE
Register Module for inclusion in hyva-themes.json

### DIFF
--- a/Observer/RegisterModuleForHyvaConfig.php
+++ b/Observer/RegisterModuleForHyvaConfig.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Hyvä Themes - https://hyva.io
+ * Copyright © Hyvä Themes 2022-present. All rights reserved.
+ * This category is licensed per Magento install
+ * See https://hyva.io/license
+ */
+
+declare(strict_types=1);
+
+namespace Monsoon\HyvaAjaxAddToCart\Observer;
+
+use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class RegisterModuleForHyvaConfig implements ObserverInterface
+{
+    private $componentRegistrar;
+
+    public function __construct(ComponentRegistrar $componentRegistrar)
+    {
+        $this->componentRegistrar = $componentRegistrar;
+    }
+
+    public function execute(Observer $event)
+    {
+        $config = $event->getData('config');
+        $extensions = $config->hasData('extensions') ? $config->getData('extensions') : [];
+
+        $moduleName = implode('_', array_slice(explode('\\', __CLASS__), 0, 2));
+
+        $path = $this->componentRegistrar->getPath(ComponentRegistrar::MODULE, $moduleName);
+
+        // Only use the path relative to the Magento base dir
+        $extensions[] = ['src' => substr($path, strlen(BP) + 1)];
+
+        $config->setData('extensions', $extensions);
+    }
+}

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -1,0 +1,6 @@
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="hyva_config_generate_before">
+        <observer name="Monsoon_HyvaAjaxAddToCart" instance="Monsoon\HyvaAjaxAddToCart\Observer\RegisterModuleForHyvaConfig"/>
+    </event>
+</config>


### PR DESCRIPTION
In the past, whenever we would run `setup:upgrade`, this module would be excluded from the `hyva-themes.json`. This module makes use of Tailwind styles to style the spinner. Thus, in my opinion, it should be included in the `tailwind-config.json` file.

To achieve this, I followed the instructions provided in the [Hyva documentation](https://docs.hyva.io/hyva-themes/compatibility-modules/tailwind-config-merging.html#registering-a-module-for-inclusion-in-hyva-themesjson), to register a module for inclusion:

+ Added `Observer \ RegisterModuleForHyvaConfig.php`
+ Added `etc \ frontend \ events.xml`